### PR TITLE
Update GeminiSearch.node.ts

### DIFF
--- a/nodes/GeminiSearch/GeminiSearch.node.ts
+++ b/nodes/GeminiSearch/GeminiSearch.node.ts
@@ -57,25 +57,53 @@ export class GeminiSearch implements INodeType {
         type: 'options',
         options: [
           {
-            name: 'Gemini 1.0 Pro',
-            value: 'gemini-1.0-pro',
+            name: 'Gemini 2.5 Flash Preview 04-17',
+            value: 'gemini-2.5-flash-preview-04-17',
           },
           {
-            name: 'Gemini 1.5 Pro',
-            value: 'gemini-1.5-pro',
+            name: 'Gemini 2.5 Pro Preview',
+            value: 'gemini-2.5-pro-preview-05-06',
           },
           {
             name: 'Gemini 2.0 Flash',
             value: 'gemini-2.0-flash',
           },
           {
-            name: 'Gemini 2.0 Pro',
-            value: 'gemini-2.0-pro',
+            name: 'Gemini 2.0 Flash Preview Image Generation',
+            value: 'gemini-2.0-flash-preview-image-generation',
           },
           {
-            name: 'Gemini 2.5 Pro',
-            value: 'gemini-2.5-pro',
+            name: 'Gemini 2.0 Flash-Lite',
+            value: 'gemini-2.0-flash-lite',
           },
+          {
+            name: 'Gemini 1.5 Flash',
+            value: 'gemini-1.5-flash',
+          },
+          {
+            name: 'Gemini 1.5 Flash-8B',
+            value: 'gemini-1.5-flash-8b',
+          },
+          {
+            name: 'Gemini 1.5 Pro',
+            value: 'gemini-1.5-pro',
+          },
+          {
+            name: 'Gemini Embedding',
+            value: 'gemini-embedding-exp',
+          },
+           {
+            name: 'Imagen 3',
+            value: 'imagen-3.0-generate-002',
+          }
+           {
+            name: 'Veo 2',
+            value: 'veo-2.0-generate-001',
+          }
+           {
+            name: 'Gemini 2.0 Flash Live',
+            value: 'gemini-2.0-flash-live-001',
+          }
         ],
         default: 'gemini-2.0-flash',
         description: 'The Gemini model to use',

--- a/nodes/GeminiSearch/GeminiSearch.node.ts
+++ b/nodes/GeminiSearch/GeminiSearch.node.ts
@@ -95,15 +95,15 @@ export class GeminiSearch implements INodeType {
            {
             name: 'Imagen 3',
             value: 'imagen-3.0-generate-002',
-          }
+          },
            {
             name: 'Veo 2',
             value: 'veo-2.0-generate-001',
-          }
+          },
            {
             name: 'Gemini 2.0 Flash Live',
             value: 'gemini-2.0-flash-live-001',
-          }
+          },
         ],
         default: 'gemini-2.0-flash',
         description: 'The Gemini model to use',


### PR DESCRIPTION
Updated modes with the ones available on https://ai.google.dev/gemini-api/docs/models as of May 2025. Not sure if there is anywhere else that needs it to be changed.

## Summary by Sourcery

Update GeminiSearch node's model selection options to align with the latest Gemini API models (May 2025).

Enhancements:
- Replace outdated Gemini model options with current preview versions and rename identifiers to match API documentation.
- Add new model options including Gemini embedding, Imagen 3, Veo 2, and additional Flash variants for image generation.